### PR TITLE
Notify to committer when a build fails

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/typetalk/TypetalkUniqueIdProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/typetalk/TypetalkUniqueIdProperty.java
@@ -1,0 +1,37 @@
+package org.jenkinsci.plugins.typetalk;
+
+import hudson.Extension;
+import hudson.model.User;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Per user property that is unique id for mention.
+ */
+public class TypetalkUniqueIdProperty extends UserProperty {
+
+    private final String uniqueId;
+
+    @DataBoundConstructor
+    public TypetalkUniqueIdProperty(String uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    public String getUniqueId() {
+        return uniqueId;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends UserPropertyDescriptor {
+        public String getDisplayName() {
+            return "Typetalk Unique ID";
+        }
+
+        @Override
+        public UserProperty newInstance(User user) {
+            return new TypetalkUniqueIdProperty(null);
+        }
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/typetalk/support/TypetalkMessage.java
+++ b/src/main/java/org/jenkinsci/plugins/typetalk/support/TypetalkMessage.java
@@ -2,8 +2,12 @@ package org.jenkinsci.plugins.typetalk.support;
 
 import hudson.model.Job;
 import hudson.model.Run;
+import hudson.scm.ChangeLogSet;
 import jenkins.model.Jenkins;
+import jenkins.scm.RunWithSCM;
 import org.apache.commons.lang.StringUtils;
+
+import java.util.List;
 
 public class TypetalkMessage {
 
@@ -41,6 +45,16 @@ public class TypetalkMessage {
 		builder.append("\n");
 		builder.append(rootUrl);
 		builder.append(build.getUrl());
+
+		if (build instanceof RunWithSCM) {
+			List<ChangeLogSet> changeSets = ((RunWithSCM) build).getChangeSets();
+
+			String uniqueIds = new UniqueIdConverter().changeSetsToAuthorUniqueIds(changeSets);
+			if (StringUtils.isNotEmpty(uniqueIds)) {
+				builder.append("\n\n");
+				builder.append(uniqueIds);
+			}
+		}
 
 		return builder.toString();
 	}

--- a/src/main/java/org/jenkinsci/plugins/typetalk/support/UniqueIdConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/typetalk/support/UniqueIdConverter.java
@@ -1,0 +1,81 @@
+package org.jenkinsci.plugins.typetalk.support;
+
+import hudson.model.User;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.GitChangeSetList;
+import hudson.scm.ChangeLogSet;
+import hudson.tasks.Mailer;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.typetalk.TypetalkUniqueIdProperty;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class UniqueIdConverter {
+
+    public String changeSetsToAuthorUniqueIds(List<ChangeLogSet> changeSets) {
+        Set<String> uniqueIds = changeSets.stream()
+                .filter(GitChangeSetList.class::isInstance)
+                .map(GitChangeSetList.class::cast)
+                .map(this::gitChangeSetListToUniqueIds)
+                .reduce(Collections.emptySet(), this::unionSets);
+        return uniqueIds.stream()
+                .map(uniqueId -> "@" + uniqueId)
+                .collect(Collectors.joining(" "));
+    }
+
+    Set<String> gitChangeSetListToUniqueIds(GitChangeSetList gitChangeSetList) {
+        return gitChangeSetList.getLogs().stream()
+                .map(this::gitChangeSetToUniqueId)
+                .filter(StringUtils::isNotEmpty)
+                .collect(Collectors.toSet());
+    }
+
+    String gitChangeSetToUniqueId(GitChangeSet gitChangeSet) {
+        return getUniqueIdFromName(gitChangeSet)
+                .orElse(getUniqueIdFromEmail(gitChangeSet)
+                        .orElse(""));
+    }
+
+    Optional<String> getUniqueIdFromName(GitChangeSet gitChangeSet) {
+        return getUniqueIdFromProperty(User.get(gitChangeSet.getAuthorName(), false, Collections.emptyMap()));
+    }
+
+    /**
+     * Return a user's unique id at random when some users have same email address
+     */
+    Optional<String> getUniqueIdFromEmail(GitChangeSet gitChangeSet) {
+        return User.getAll().stream()
+                .filter(user -> isSameAddress(gitChangeSet, user))
+                .map(this::getUniqueIdFromProperty)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+    }
+
+    Optional<String> getUniqueIdFromProperty(User user) {
+        if (user == null) {
+            return Optional.empty();
+        }
+
+        TypetalkUniqueIdProperty property = user.getProperty(TypetalkUniqueIdProperty.class);
+        if (property == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(property.getUniqueId());
+    }
+
+    boolean isSameAddress(GitChangeSet gitChangeSet, User user) {
+        return gitChangeSet.getAuthorEmail().equals(user.getProperty(Mailer.UserProperty.class).getAddress());
+    }
+
+    Set<String> unionSets(Set<String> set1, Set<String> set2) {
+        HashSet<String> result = new HashSet<>();
+        result.addAll(set1);
+        result.addAll(set2);
+
+        return result;
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/typetalk/TypetalkUniqueIdProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/typetalk/TypetalkUniqueIdProperty/config.jelly
@@ -1,0 +1,5 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Unique ID}" field="uniqueId">
+    <f:textbox />
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/typetalk/TypetalkUniqueIdProperty/help-uniqueId.html
+++ b/src/main/resources/org/jenkinsci/plugins/typetalk/TypetalkUniqueIdProperty/help-uniqueId.html
@@ -1,0 +1,4 @@
+<div>
+Input same unique ID as the ID in your <a href="https://apps.nulab-inc.com/account/settings/profile" target="_blank">profile</a>.
+This ID will be used in @mention with a notification to Typetalk.
+</div>

--- a/src/test/groovy/org/jenkinsci/plugins/typetalk/support/UniqueIdConverterSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/typetalk/support/UniqueIdConverterSpec.groovy
@@ -1,0 +1,100 @@
+package org.jenkinsci.plugins.typetalk.support
+
+import hudson.model.User
+import hudson.plugins.git.GitChangeSet
+import hudson.plugins.git.GitChangeSetList
+import hudson.tasks.Mailer
+import org.jenkinsci.plugins.typetalk.TypetalkUniqueIdProperty
+import org.junit.Rule
+import org.jvnet.hudson.test.JenkinsRule
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class UniqueIdConverterSpec extends Specification {
+
+    @Rule JenkinsRule j
+
+    def converter = new UniqueIdConverter()
+
+    def setup() {
+        (1..3).each {
+            setupUser("name-$it", "email-$it@example.com", "unique-$it")
+        }
+    }
+
+    @Unroll
+    def "gitChangeSetListToUniqueIds"() {
+        setup:
+        def changeLogSet = new GitChangeSetList(null, null, names.collect { makeGitChangeSet(it, '') })
+
+        expect:
+        converter.gitChangeSetListToUniqueIds(changeLogSet) == uniqueIds as Set
+
+        where:
+        names                          || uniqueIds
+        ['name-1', 'name-2', 'name-1'] || ['unique-1', 'unique-2']
+        ['name-1', 'dummy']            || ['unique-1']
+    }
+
+    @Unroll
+    def "gitChangeSetToUniqueId : #name - #email"() {
+        setup:
+        def gitChangeSet = makeGitChangeSet(name, email)
+
+        expect:
+        converter.gitChangeSetToUniqueId(gitChangeSet) == uniqueId
+
+        where:
+        name     | email                 || uniqueId
+        'name-1' | 'dummy@example.com'   || 'unique-1'
+        'dummy'  | 'email-2@example.com' || 'unique-2'
+        'none'   | 'none@example.com'    || ''
+    }
+
+    @Unroll
+    def "getUniqueIdFromName : #name"() {
+        setup:
+        def gitChangeSet = makeGitChangeSet(name, '')
+
+        expect:
+        converter.getUniqueIdFromName(gitChangeSet) == uniqueId
+
+        where:
+        name     || uniqueId
+        'name-1' || Optional.of('unique-1')
+        'none'   || Optional.empty()
+    }
+
+    @Unroll
+    def "getUniqueIdFromEmail : #email"() {
+        setup:
+        setupUser('empty', 'empty@example.com', null)
+        def gitChangeSet = makeGitChangeSet('', email)
+
+        expect:
+        converter.getUniqueIdFromEmail(gitChangeSet) == uniqueId
+
+        where:
+        email                 || uniqueId
+        'email-1@example.com' || Optional.of('unique-1')
+        'none@example.com'    || Optional.empty()
+        'empty@example.com'   || Optional.empty()
+    }
+
+    // --- helper method ---
+
+    def setupUser(name, email, uniqueId) {
+        def user = User.get(name)
+        user.addProperty(new Mailer.UserProperty(email))
+        user.addProperty(new TypetalkUniqueIdProperty(uniqueId))
+    }
+
+    def makeGitChangeSet(name, email) {
+        def gitChangeSet = new GitChangeSet([], false)
+        gitChangeSet.committer = name
+        gitChangeSet.committerEmail = email
+
+        gitChangeSet
+    }
+
+}


### PR DESCRIPTION
With this PR, Jenkins can notify to committer automatically when a build fails ( see an attached capture )

![capture](https://user-images.githubusercontent.com/26503/45038705-bef64f00-b09c-11e8-8fdf-cbdc1585d5bc.png)