### PR TITLE
Fix parse error

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/typetalk/TypetalkBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/typetalk/TypetalkBuildWrapper.java
@@ -9,6 +9,7 @@ import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 import org.jenkinsci.plugins.typetalk.delegate.BuildWrapperDelegate;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.IOException;
 
@@ -35,7 +36,11 @@ public class TypetalkBuildWrapper extends BuildWrapper {
 
 	@Override
 	public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
-		final BuildWrapperDelegate delegate = new BuildWrapperDelegate(name, Long.valueOf(topicNumber), Long.valueOf(talkNumber), listener, build);
+		Long talkIdLong = null;
+		if (StringUtils.isNotEmpty(talkNumber)) {
+			talkIdLong = Long.parseLong(talkNumber);
+		}
+		final BuildWrapperDelegate delegate = new BuildWrapperDelegate(name, Long.valueOf(topicNumber), talkIdLong, listener, build);
 		delegate.notifyStart(notifyStart, notifyStartMessage);
 
 		return new Environment() {

--- a/src/main/resources/org/jenkinsci/plugins/typetalk/TypetalkBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/typetalk/TypetalkBuildWrapper/config.jelly
@@ -16,6 +16,10 @@
 		<f:textbox />
 	</f:entry>
 
+	<f:entry title="${%Talk Number}" field="talkNumber">
+		<f:textbox />
+	</f:entry>
+
 	<f:entry title="${%Notify start}" field="notifyStart">
 		<f:checkbox />
 	</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/typetalk/pipeline/TypetalkBuildWrapperStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/typetalk/pipeline/TypetalkBuildWrapperStep/config.jelly
@@ -16,6 +16,10 @@
 		<f:textbox />
 	</f:entry>
 
+	<f:entry title="${%Talk Number}" field="talkId">
+		<f:textbox />
+	</f:entry>
+
 	<f:entry title="${%Notify start}" field="notifyStart">
 		<f:checkbox />
 	</f:entry>


### PR DESCRIPTION
An error occurs when you use notification feature on the following events.
- when build starts / ends
- when build fails

```
FATAL: null
java.lang.NumberFormatException: null
	at java.lang.Long.parseLong(Long.java:552)
	at java.lang.Long.valueOf(Long.java:803)
	at org.jenkinsci.plugins.typetalk.TypetalkBuildWrapper.setUp(TypetalkBuildWrapper.java:38)
	at hudson.model.Build$BuildExecution.doRun(Build.java:157)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
	at hudson.model.Run.execute(Run.java:1806)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Finished: FAILURE
```

I also changed to provide form to input talk id for those events.