### PR TITLE
Update dependencies for local development

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,20 +14,27 @@ dependencies {
 	}
 	testCompile	'cglib:cglib-nodep:3.2.6',
 			'org.objenesis:objenesis:1.3'
-	jenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-step-api:2.13',
-			'org.jenkins-ci.plugins.workflow:workflow-job:2.16',
+	jenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-step-api:2.16',
+			'org.jenkins-ci.plugins.workflow:workflow-job:2.25',
+			'org.jenkins-ci.plugins.workflow:workflow-api:2.29',
+			'org.jenkins-ci.plugins.workflow:workflow-scm-step:2.6',
+			'org.jenkins-ci.plugins:script-security:1.46',
+			'org.jenkins-ci.plugins:credentials:2.1.18',
+			'org.jenkins-ci.plugins:scm-api:2.2.7',
 			'org.jenkins-ci.plugins:git:3.7.0',
-			'org.jenkins-ci.plugins:mailer:1.20'
+			'org.jenkins-ci.plugins:mailer:1.20',
+			'org.jenkins-ci.plugins:display-url-api:2.2.0',
+			'org.jenkins-ci.plugins:apache-httpcomponents-client-4-api:4.5.5-3.0'
 	jenkinsTest 'org.jenkins-ci.plugins:ant:1.2',
-			'org.jenkins-ci.plugins.workflow:workflow-step-api:2.13',
-			'org.jenkins-ci.plugins.workflow:workflow-job:2.16',
+			'org.jenkins-ci.plugins.workflow:workflow-step-api:2.16',
+			'org.jenkins-ci.plugins.workflow:workflow-job:2.25',
 			'org.jenkins-ci.plugins.workflow:workflow-api:2.22',
 			'org.jenkins-ci.main:jenkins-test-harness:2.33',
 			'joda-time:joda-time:2.9.5'
 }
 
 jenkinsPlugin {
-	coreVersion = '2.89.3'
+	coreVersion = '2.143'
 	shortName = 'typetalk'
 	displayName = 'Typetalk Plugin'
 	url = 'https://wiki.jenkins-ci.org/display/JENKINS/Typetalk+Plugin'


### PR DESCRIPTION
Currently, errors occur when I run `./gradlew clean server`. It seems it fails to resolve dependencies.
I updated dependencies for local development.
Could you please review it?