### PR TITLE
Use ignoreHashtag parameter for posting message

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/typetalk/api/MessageEntity.java
+++ b/src/main/java/org/jenkinsci/plugins/typetalk/api/MessageEntity.java
@@ -8,6 +8,9 @@ public class MessageEntity {
 	private String message;
 
 	@Key
+	private Boolean ignoreHashtag;
+
+	@Key
 	private Long[] talkIds;
 
 	@Key
@@ -22,6 +25,14 @@ public class MessageEntity {
 
 	public void setMessage(String message) {
 		this.message = message;
+	}
+
+	public void setIgnoreHashtag(Boolean ignoreHashtag) {
+		this.ignoreHashtag = ignoreHashtag;
+	}
+
+	public Boolean getIgnoreHashtag(Boolean ignoreHashtag) {
+		return ignoreHashtag;
 	}
 
 	public Long[] getTalkIds() {

--- a/src/main/java/org/jenkinsci/plugins/typetalk/api/Typetalk.java
+++ b/src/main/java/org/jenkinsci/plugins/typetalk/api/Typetalk.java
@@ -81,6 +81,11 @@ public class Typetalk {
 		entity.setMessage(message);
 		entity.setTalkIds(new Long[]{talkId});
 
+		// If '#' is included in the message, Typetalk will create a tag.
+		// Set true to prevent from creating tag.
+		// Tags might be created unexpectedly since `#` might be included in the string passed by Jenkins.
+		entity.setIgnoreHashtag(true);
+
 		final HttpContent content = new JsonHttpContent(JSON_FACTORY, entity);
 		final HttpRequest request = createRequestFactory().buildPostRequest(url, content);
 		HttpResponse response = request.execute();

--- a/src/main/java/org/jenkinsci/plugins/typetalk/webhookaction/WebhookExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/typetalk/webhookaction/WebhookExecutor.java
@@ -58,6 +58,11 @@ public abstract class WebhookExecutor {
         jsonObject.element("message", typetalkMessage.buildMessageWithProject(parameter.getProject()));
         jsonObject.element("replyTo", req.getPostId());
 
+        // If '#' is included in the message, Typetalk will create a tag.
+        // Set true to prevent from creating tag.
+        // Tags might be created unexpectedly since `#` might be included in the string passed by Jenkins.
+        jsonObject.element("ignoreHashtag", true);
+
         return jsonObject.toString();
     }
 }


### PR DESCRIPTION
## Changes

- Use `ignoreHashtag` parameter.

Now Typetalk creates tags using `#` in the message. In some cases, the string passed by Jenkins contains `#` and it results in creating tags unexpectedly.
https://www.typetalk.com/blog/talks-are-now-tags-in-typetalk-use-a-hashtag-to-add-them/
