### PR TITLE
Fix occurring IllegalArgumentException in the declarative pipeline.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/typetalk/support/ResultSupport.java
+++ b/src/main/java/org/jenkinsci/plugins/typetalk/support/ResultSupport.java
@@ -36,7 +36,11 @@ public class ResultSupport {
     }
 
     private boolean isSuccessCurrentBuild(Run build) {
-        return build instanceof WorkflowRun ? build.getResult() == null : build.getResult().equals(Result.SUCCESS);
+        final Result result = build.getResult();
+        if (result == null) {
+            return build instanceof WorkflowRun;
+        }
+        return result.equals(Result.SUCCESS);
     }
 
     private boolean isSuccessPreviousBuild(Run build) {


### PR DESCRIPTION
Sometimes the result property of the Run parameter is not null even if it is an instance of WorkflowRun.
