### PR TITLE
Downgrade google-http-client and google-oauth-client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ version = '1.3.1-SNAPSHOT'
 description = 'Typetalk Plugin'
 
 dependencies {
-	implementation 'com.google.http-client:google-http-client-gson:1.40.0'
-	implementation 'com.google.oauth-client:google-oauth-client:1.32.1'
+	implementation 'com.google.http-client:google-http-client-gson:1.27.0'
+	implementation 'com.google.oauth-client:google-oauth-client:1.27.0'
 	implementation 'org.jenkins-ci.plugins.workflow:workflow-step-api:2.13'
 	implementation 'org.jenkins-ci.plugins.workflow:workflow-job:2.16'
 	implementation 'org.jenkins-ci.plugins:git:3.7.0'

--- a/src/test/groovy/org/jenkinsci/plugins/typetalk/TypetalkSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/typetalk/TypetalkSpec.groovy
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.typetalk
 
-import org.apache.commons.httpclient.HttpStatus
+import org.apache.http.HttpStatus
 import org.jenkinsci.plugins.typetalk.api.Typetalk
 import spock.lang.Ignore
 import spock.lang.Specification
@@ -17,10 +17,10 @@ class TypetalkSpec extends Specification {
 	@Ignore("not post normally")
 	def postMessage() {
 		setup:
-		Typetalk typetalk = new Typetalk(config['client.id'], config['client.secret'])
+		Typetalk typetalk = new Typetalk(config['client.id'] as String, config['client.secret'] as String)
 
 		expect:
-		typetalk.postMessage(config['topic.id'].toLong(), "TypetalkSpec : ${new Date()}") == HttpStatus.SC_OK
+		typetalk.postMessage(config['topic.id'] as long, "TypetalkSpec : ${new Date()}", null) == HttpStatus.SC_OK
 	}
 
 }


### PR DESCRIPTION
Post to Typetalk by TypetalkSpec was successful, but NoSuchMethodError has occurred when it was installed and execute posting in Jenkins.
This problem looks caused by multiple Guava library versions.
So downgrade google-http-client and google-oauth-client to versions that does not cause this problem.
And fix TypetalkSpec.